### PR TITLE
BIDDER-3684 - Add method to disable WAL file

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -39,11 +39,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-import java.util.stream.Collectors;
 
 import io.confluent.connect.hdfs.avro.AvroFormat;
 import io.confluent.connect.hdfs.json.JsonFormat;
@@ -51,7 +49,6 @@ import io.confluent.connect.hdfs.orc.OrcFormat;
 import io.confluent.connect.hdfs.parquet.ParquetFormat;
 import io.confluent.connect.hdfs.storage.HdfsStorage;
 import io.confluent.connect.hdfs.string.StringFormat;
-import io.confluent.connect.hdfs.parquet.ParquetFormat;
 import io.confluent.connect.storage.StorageSinkConnectorConfig;
 import io.confluent.connect.storage.common.ComposableConfig;
 import io.confluent.connect.storage.common.GenericRecommender;
@@ -72,9 +69,6 @@ import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.utils.Utils;
-import org.apache.parquet.hadoop.metadata.CompressionCodecName;
-
 import org.apache.kafka.common.utils.Utils;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
@@ -165,6 +159,12 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
       "The period in milliseconds to renew the Kerberos ticket.";
   private static final String KERBEROS_TICKET_RENEW_PERIOD_MS_DISPLAY = "Kerberos Ticket Renew "
       + "Period (ms)";
+
+  public static final String DISABLE_WAL_CONFIG = "wal.disable";
+  private static final boolean DISABLE_WAL_DEFAULT = false;
+  private static final String DISABLE_WAL_DOC = "Disable WAL from being used to track the "
+      + " committed files - can be used for testing the fallback methods";
+  private static final String DISABLE_WAL_DISPLAY = "Disable WAL";
 
   private static final Pattern SUBSTITUTION_PATTERN = Pattern.compile("\\$\\{(\\d+)}");
   private static final Pattern INVALID_SUB_PATTERN = Pattern.compile("\\$\\{.*}");
@@ -275,6 +275,19 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
               Width.SHORT,
               HIVE_TABLE_NAME_DISPLAY
       );
+
+      configDef.define(
+          DISABLE_WAL_CONFIG,
+          Type.BOOLEAN,
+          DISABLE_WAL_DEFAULT,
+          Importance.LOW,
+          DISABLE_WAL_DOC,
+          group,
+          ++orderInGroup,
+          Width.MEDIUM,
+          DISABLE_WAL_DISPLAY
+      );
+
     }
 
     {

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.hdfs;
 
+import io.confluent.connect.hdfs.wal.NoopWAL;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.common.TopicPartition;
@@ -201,7 +202,8 @@ public class TopicPartitionWriter {
         config.getString(StorageSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG));
 
     String logsDir = config.getLogsDirFromTopic(tp.topic());
-    wal = storage.wal(logsDir, tp);
+    boolean disableWal = config.getBoolean(HdfsSinkConnectorConfig.DISABLE_WAL_CONFIG);
+    wal = disableWal ? new NoopWAL() : storage.wal(logsDir, tp);
 
     buffer = new LinkedList<>();
     writers = new HashMap<>();

--- a/src/main/java/io/confluent/connect/hdfs/wal/NoopWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/NoopWAL.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs.wal;
+
+import io.confluent.connect.storage.wal.FilePathOffset;
+import org.apache.kafka.connect.errors.ConnectException;
+
+/**
+ * NoopWAL - is a blank implementation of WAL - it can be used for testing the WAL fallback
+ * methods
+ */
+public class NoopWAL implements WAL {
+  @Override
+  public void acquireLease() throws ConnectException {
+
+  }
+
+  @Override
+  public void append(String s, String s1) throws ConnectException {
+
+  }
+
+  @Override
+  public void apply() throws ConnectException {
+
+  }
+
+  @Override
+  public void truncate() throws ConnectException {
+
+  }
+
+  @Override
+  public void close() throws ConnectException {
+
+  }
+
+  @Override
+  public String getLogFile() {
+    return null;
+  }
+
+  @Override
+  public FilePathOffset extractLatestOffset() {
+    return null;
+  }
+}


### PR DESCRIPTION
To do this I've create a new option wal.disable defaulted to false. I then created a blank/dummy/noop implementation of WAL which is used if this is set to true.

This means whenever trying to perform any operation with a WAL file nothing actually happens and when it comes to retrieving the latest offset we will fall through to using the next best method.

## Problem


## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
