### PR TITLE
fix: Update parquet version to 1.13.1 to fix PARQUET-2052

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,6 +375,11 @@
             <version>1.13.1</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop-bundle</artifactId>
+            <version>1.13.1</version>
+        </dependency>
+        <dependency>
             <!-- add this to satisfy the dependency requirement of apacheds-jdbm1-->
             <groupId>org.apache.directory.jdbm</groupId>
             <artifactId>apacheds-jdbm1</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,18 @@
             <version>${confluent-log4j.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Update parquet dependencies to fix PARQUET-2052 -->
+        <!-- https://github.com/apache/parquet-mr/pull/910 -->
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-column</artifactId>
+            <version>1.13.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-avro</artifactId>
+            <version>1.13.1</version>
+        </dependency>
         <dependency>
             <!-- add this to satisfy the dependency requirement of apacheds-jdbm1-->
             <groupId>org.apache.directory.jdbm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -363,8 +363,7 @@
             <version>${confluent-log4j.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- Update parquet dependencies to fix PARQUET-2052 -->
-        <!-- https://github.com/apache/parquet-mr/pull/910 -->
+        <!-- Update parquet dependencies to fix PARQUET-2052 https://github.com/apache/parquet-mr/pull/910 -->
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-column</artifactId>


### PR DESCRIPTION
## Problem
`DictionaryValuesWriter` throws `OutOfBoundException` time to time and it stops the running task.

## Solution
The issue might have been fixed by  https://github.com/apache/parquet-mr/pull/910. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
