### PR TITLE
ParquetRecordWriterProvider - Add null check on underlying ParquetWriter

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
@@ -116,6 +116,9 @@ public class ParquetRecordWriterProvider
       }
 
       public long size() {
+        if (writer == null) {
+          return 0;
+        }
         return writer.getDataSize();
       }
 

--- a/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
@@ -56,6 +56,9 @@ public class ParquetRecordWriterProvider
     return new SizeAwareRecordWriter() {
       @Override
       public long getDataSize() {
+        if (writer == null) {
+          return 0;
+        }
         return writer.getDataSize();
       }
 


### PR DESCRIPTION
Fixes edge case where it's possible that getDataSize() is called before the first call to write().

## Problem


## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
