### PR TITLE
feat: Introduce QFSWAL based on the atomic rename

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,6 +375,11 @@
             <version>1.13.1</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop-bundle</artifactId>
+            <version>1.13.1</version>
+        </dependency>
+        <dependency>
             <!-- add this to satisfy the dependency requirement of apacheds-jdbm1-->
             <groupId>org.apache.directory.jdbm</groupId>
             <artifactId>apacheds-jdbm1</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,18 @@
             <version>${confluent-log4j.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Update parquet dependencies to fix PARQUET-2052 -->
+        <!-- https://github.com/apache/parquet-mr/pull/910 -->
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-column</artifactId>
+            <version>1.13.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-avro</artifactId>
+            <version>1.13.1</version>
+        </dependency>
         <dependency>
             <!-- add this to satisfy the dependency requirement of apacheds-jdbm1-->
             <groupId>org.apache.directory.jdbm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -363,8 +363,7 @@
             <version>${confluent-log4j.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- Update parquet dependencies to fix PARQUET-2052 -->
-        <!-- https://github.com/apache/parquet-mr/pull/910 -->
+        <!-- Update parquet dependencies to fix PARQUET-2052 https://github.com/apache/parquet-mr/pull/910 -->
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-column</artifactId>

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -49,6 +49,7 @@ import io.confluent.connect.hdfs.orc.OrcFormat;
 import io.confluent.connect.hdfs.parquet.ParquetFormat;
 import io.confluent.connect.hdfs.storage.HdfsStorage;
 import io.confluent.connect.hdfs.string.StringFormat;
+import io.confluent.connect.hdfs.wal.WalType;
 import io.confluent.connect.storage.StorageSinkConnectorConfig;
 import io.confluent.connect.storage.common.ComposableConfig;
 import io.confluent.connect.storage.common.GenericRecommender;
@@ -167,9 +168,6 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
       + "Period (ms)";
 
   public static final String WAL_TYPE = "wal.type";
-  public static final String WAL_NOOP = "NOOP";
-  public static final String WAL_HDFS = "HDFS";
-  public static final String WAL_QFS = "QFS";
 
   private static final String DISABLE_WAL_DOC = "Disable WAL from being used to track the "
       + " committed files - can be used for testing the fallback methods";
@@ -288,7 +286,7 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
       configDef.define(
           WAL_TYPE,
           Type.STRING,
-          WAL_HDFS,
+          WalType.HDFS.name(),
           Importance.LOW,
           DISABLE_WAL_DOC,
           group,

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -166,8 +166,11 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
   private static final String KERBEROS_TICKET_RENEW_PERIOD_MS_DISPLAY = "Kerberos Ticket Renew "
       + "Period (ms)";
 
-  public static final String DISABLE_WAL_CONFIG = "wal.disable";
-  private static final boolean DISABLE_WAL_DEFAULT = false;
+  public static final String WAL_TYPE = "wal.type";
+  public static final String WAL_NOOP = "NOOP";
+  public static final String WAL_HDFS = "HDFS";
+  public static final String WAL_QFS = "QFS";
+
   private static final String DISABLE_WAL_DOC = "Disable WAL from being used to track the "
       + " committed files - can be used for testing the fallback methods";
   private static final String DISABLE_WAL_DISPLAY = "Disable WAL";
@@ -283,9 +286,9 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
       );
 
       configDef.define(
-          DISABLE_WAL_CONFIG,
-          Type.BOOLEAN,
-          DISABLE_WAL_DEFAULT,
+          WAL_TYPE,
+          Type.STRING,
+          WAL_HDFS,
           Importance.LOW,
           DISABLE_WAL_DOC,
           group,

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -15,7 +15,7 @@
 
 package io.confluent.connect.hdfs;
 
-import io.confluent.connect.hdfs.wal.NoopWAL;
+import io.confluent.connect.hdfs.wal.WalType;
 import io.confluent.connect.storage.format.RecordWriter;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -210,15 +210,9 @@ public class TopicPartitionWriter {
 
     String logsDir = config.getLogsDirFromTopic(tp.topic());
 
-    String walType = config.getString(HdfsSinkConnectorConfig.WAL_TYPE);
-
-    if (walType.equalsIgnoreCase(HdfsSinkConnectorConfig.WAL_NOOP)) {
-      wal = new NoopWAL();
-    } else if (walType.equalsIgnoreCase(HdfsSinkConnectorConfig.WAL_QFS)) {
-      wal = storage.wal(logsDir, tp, true);
-    } else {
-      wal = storage.wal(logsDir, tp, false);
-    }
+    wal = WalType.valueOf(
+            config.getString(HdfsSinkConnectorConfig.WAL_TYPE)
+    ).create(logsDir, tp, storage);
 
     buffer = new LinkedList<>();
     writers = new HashMap<>();

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -210,7 +210,7 @@ public class TopicPartitionWriter {
 
     String logsDir = config.getLogsDirFromTopic(tp.topic());
     boolean disableWal = config.getBoolean(HdfsSinkConnectorConfig.DISABLE_WAL_CONFIG);
-    wal = disableWal ? new NoopWAL() : storage.wal(logsDir, tp);
+    wal = disableWal ? new NoopWAL() : storage.wal(logsDir, tp, true);
 
     buffer = new LinkedList<>();
     writers = new HashMap<>();

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -209,8 +209,16 @@ public class TopicPartitionWriter {
         config.getString(StorageSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG));
 
     String logsDir = config.getLogsDirFromTopic(tp.topic());
-    boolean disableWal = config.getBoolean(HdfsSinkConnectorConfig.DISABLE_WAL_CONFIG);
-    wal = disableWal ? new NoopWAL() : storage.wal(logsDir, tp, true);
+
+    String walType = config.getString(HdfsSinkConnectorConfig.WAL_TYPE);
+
+    if (walType.equalsIgnoreCase(HdfsSinkConnectorConfig.WAL_NOOP)) {
+      wal = new NoopWAL();
+    } else if (walType.equalsIgnoreCase(HdfsSinkConnectorConfig.WAL_QFS)) {
+      wal = storage.wal(logsDir, tp, true);
+    } else {
+      wal = storage.wal(logsDir, tp, false);
+    }
 
     buffer = new LinkedList<>();
     writers = new HashMap<>();

--- a/src/main/java/io/confluent/connect/hdfs/storage/HdfsStorage.java
+++ b/src/main/java/io/confluent/connect/hdfs/storage/HdfsStorage.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.hdfs.storage;
 
+import io.confluent.connect.hdfs.wal.FSWAL;
 import io.confluent.connect.hdfs.wal.QFSWAL;
 import org.apache.avro.file.SeekableInput;
 import org.apache.avro.mapred.FsInput;
@@ -178,6 +179,14 @@ public class HdfsStorage
   }
 
   public WAL wal(String topicsDir, TopicPartition topicPart) {
+    return wal(topicsDir, topicPart, false);
+  }
+
+  public WAL wal(String topicsDir, TopicPartition topicPart, boolean qfsWal) {
+    if (qfsWal) {
+      return new FSWAL(topicsDir, topicPart, this);
+    }
+
     return new QFSWAL(topicsDir, topicPart, this);
   }
 

--- a/src/main/java/io/confluent/connect/hdfs/storage/HdfsStorage.java
+++ b/src/main/java/io/confluent/connect/hdfs/storage/HdfsStorage.java
@@ -184,10 +184,10 @@ public class HdfsStorage
 
   public WAL wal(String topicsDir, TopicPartition topicPart, boolean qfsWal) {
     if (qfsWal) {
-      return new FSWAL(topicsDir, topicPart, this);
+      return new QFSWAL(topicsDir, topicPart, this);
     }
 
-    return new QFSWAL(topicsDir, topicPart, this);
+    return new FSWAL(topicsDir, topicPart, this);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/hdfs/storage/HdfsStorage.java
+++ b/src/main/java/io/confluent/connect/hdfs/storage/HdfsStorage.java
@@ -178,15 +178,11 @@ public class HdfsStorage
     }
   }
 
-  public WAL wal(String topicsDir, TopicPartition topicPart) {
-    return wal(topicsDir, topicPart, false);
+  public WAL qfsWAL(String topicsDir, TopicPartition topicPart) {
+    return new QFSWAL(topicsDir, topicPart, this);
   }
 
-  public WAL wal(String topicsDir, TopicPartition topicPart, boolean qfsWal) {
-    if (qfsWal) {
-      return new QFSWAL(topicsDir, topicPart, this);
-    }
-
+  public WAL hdfsWAL(String topicsDir, TopicPartition topicPart) {
     return new FSWAL(topicsDir, topicPart, this);
   }
 

--- a/src/main/java/io/confluent/connect/hdfs/storage/HdfsStorage.java
+++ b/src/main/java/io/confluent/connect/hdfs/storage/HdfsStorage.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.hdfs.storage;
 
+import io.confluent.connect.hdfs.wal.QFSWAL;
 import org.apache.avro.file.SeekableInput;
 import org.apache.avro.mapred.FsInput;
 import org.apache.hadoop.fs.FileStatus;
@@ -31,7 +32,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
-import io.confluent.connect.hdfs.wal.FSWAL;
 import io.confluent.connect.hdfs.wal.WAL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -178,7 +178,7 @@ public class HdfsStorage
   }
 
   public WAL wal(String topicsDir, TopicPartition topicPart) {
-    return new FSWAL(topicsDir, topicPart, this);
+    return new QFSWAL(topicsDir, topicPart, this);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
@@ -215,6 +215,7 @@ public class QFSWAL implements WAL {
   @Override
   public void close() throws ConnectException {
     this.timer.cancel();
+    this.storage.delete(this.lockFile);
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
@@ -3,7 +3,6 @@ package io.confluent.connect.hdfs.wal;
 import io.confluent.connect.hdfs.FileUtils;
 import io.confluent.connect.hdfs.storage.HdfsStorage;
 import io.confluent.connect.storage.wal.FilePathOffset;
-import io.confluent.connect.storage.wal.WAL;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;

--- a/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
@@ -75,9 +75,9 @@ public class QFSWAL implements WAL {
     this.logsDir = logsDir;
     this.topicPartition = topicPartition;
     this.lockDir = FileUtils.directoryName(storage.url(), logsDir, topicPartition);
-    this.lockFile = this.createOrRenameLockFile();
     this.lockRefreshIntervalInMs = lockRefreshIntervalInMs;
     this.lockTimeoutInMs = lockTimeoutInMs;
+    this.lockFile = this.createOrRenameLockFile();
     this.startRenamingTimer();
   }
 

--- a/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
@@ -19,25 +19,27 @@ import io.confluent.connect.hdfs.FileUtils;
 import io.confluent.connect.hdfs.storage.HdfsStorage;
 import io.confluent.connect.storage.wal.FilePathOffset;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.AbstractMap.SimpleEntry;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class QFSWAL implements WAL {
   private static final String LOCK_FILE_EXTENSION = "lock-qfs";
-  private static final int DEFAULT_LOCK_REFRESH_INTERVAL_IN_MS = 10_000;
-  private static final int DEFAULT_LOCK_TIMEOUT_IN_MS = 60_000;
+
+  private static final Duration DEFAULT_LOCK_REFRESH_INTERVAL = Duration.ofSeconds(10);
+  private static final Duration DEFAULT_LOCK_TIMEOUT = Duration.ofSeconds(60);
   private final UUID uuid;
   private final Timer timer;
   private final HdfsStorage storage;
@@ -45,89 +47,108 @@ public class QFSWAL implements WAL {
   private final TopicPartition topicPartition;
   private final Pattern pattern;
   private final String lockDir;
-  private String lockFile;
-
-  private final int lockRefreshIntervalInMs;
-  private final int lockTimeoutInMs;
+  private LockFile lockFile;
+  private final Duration lockRefreshInterval;
+  private final Duration lockTimeout;
   private static final Logger log = LoggerFactory.getLogger(QFSWAL.class);
 
   public QFSWAL(String logsDir, TopicPartition topicPartition, HdfsStorage storage) {
     this(logsDir,
-         topicPartition,
-         storage,
-         DEFAULT_LOCK_REFRESH_INTERVAL_IN_MS,
-         DEFAULT_LOCK_TIMEOUT_IN_MS);
+        topicPartition,
+        storage,
+        DEFAULT_LOCK_REFRESH_INTERVAL,
+        DEFAULT_LOCK_TIMEOUT
+    );
   }
 
   public QFSWAL(
           String logsDir,
           TopicPartition topicPartition,
           HdfsStorage storage,
-          int lockRefreshIntervalInMs,
-          int lockTimeoutInMs
-  ) {
+          Duration lockRefreshInterval,
+          Duration lockTimeout) {
     this.uuid = UUID.randomUUID();
     this.pattern = Pattern.compile(String.format(
-            "([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-(\\d+)(\\.)%s",
+            "(?<uuid>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"
+                    + "-(?<epoch>\\d+)(\\.)%s",
             LOCK_FILE_EXTENSION));
     this.timer = new Timer("QFSWAL-Timer", true);
     this.storage = storage;
     this.logsDir = logsDir;
     this.topicPartition = topicPartition;
     this.lockDir = FileUtils.directoryName(storage.url(), logsDir, topicPartition);
-    this.lockRefreshIntervalInMs = lockRefreshIntervalInMs;
-    this.lockTimeoutInMs = lockTimeoutInMs;
+    this.lockRefreshInterval = lockRefreshInterval;
+    this.lockTimeout = lockTimeout;
     this.lockFile = this.createOrRenameLockFile();
     this.startRenamingTimer();
   }
 
-  private String getNewLockFile() {
-    return FileUtils.fileName(storage.url(),
-                              this.logsDir,
-                              this.topicPartition,
-                              String.format("%s-%s.%s",
-                                            this.uuid,
-                                            System.currentTimeMillis(),
-                                            LOCK_FILE_EXTENSION));
+  static class LockFile {
+    public final String storageURL;
+    public final String logsDir;
+    public final TopicPartition topicPartition;
+    public final UUID uuid;
+    public final Instant instant;
+
+    LockFile(
+            String storageURL,
+            String logsDir,
+            TopicPartition topicPartition,
+            UUID uuid,
+            Instant instant
+    ) {
+      this.storageURL = storageURL;
+      this.logsDir = logsDir;
+      this.topicPartition = topicPartition;
+      this.uuid = uuid;
+      this.instant = instant;
+    }
+
+    public String filePath() {
+      return FileUtils.fileName(
+              storageURL,
+              logsDir,
+              topicPartition,
+              String.format("%s-%s.%s", uuid, instant.toEpochMilli(), LOCK_FILE_EXTENSION)
+      );
+    }
   }
 
-  private String createOrRenameLockFile() {
+  private LockFile getNewLockFile() {
+    return new LockFile(
+            this.storage.url(),
+            this.logsDir,
+            this.topicPartition,
+            this.uuid,
+            Instant.now()
+    );
+  }
+
+  private LockFile createOrRenameLockFile() {
     if (!this.storage.exists(this.lockDir)) {
       this.storage.create(this.lockDir);
     }
 
-    List<SimpleEntry<String, Matcher>> lockFiles = this.findLockFiles();
-    String newLockFile = getNewLockFile();
+    LockFile newLockFile = getNewLockFile();
 
-    long liveLocksCount = lockFiles.stream()
-            .filter(pair -> Long.parseLong(
-                    pair.getValue().group(2))
-                    > System.currentTimeMillis() - this.lockTimeoutInMs
-             ).count();
+    List<LockFile> liveLockFiles = this.findLockFiles()
+            .stream()
+            .filter(l -> l.instant.isAfter(Instant.now().minus(this.lockTimeout)))
+            .collect(Collectors.toList());
 
-    if (liveLocksCount != 0) {
+    if (!liveLockFiles.isEmpty()) {
       throw new ConnectException("Lock has been acquired by another process");
     }
 
-    if (lockFiles.isEmpty()) {
-      this.storage.create(newLockFile, true);
-    } else {
-      String oldLockFile = FileUtils.fileName(storage.url(),
-                                              this.logsDir,
-                                              this.topicPartition,
-                                              lockFiles.get(0).getKey());
-      this.storage.commit(oldLockFile, newLockFile);
-    }
+    this.storage.create(newLockFile.filePath(), true);
 
-    liveLocksCount = this.findLockFiles()
+    liveLockFiles = this.findLockFiles()
             .stream()
-            .filter(pair -> Long.parseLong(
-                    pair.getValue().group(2))
-                    > System.currentTimeMillis() - this.lockTimeoutInMs
-            ).count();
+            .filter(l -> l.instant.isAfter(Instant.now().minus(this.lockTimeout)))
+            .collect(Collectors.toList());
 
-    if (liveLocksCount > 1) {
-      this.storage.delete(newLockFile);
+    if (liveLockFiles.size() > 1) {
+      this.storage.delete(newLockFile.filePath());
       throw new ConnectException("Lock has been acquired by another process");
     }
 
@@ -141,38 +162,43 @@ public class QFSWAL implements WAL {
       public void run() {
         renameLockFile();
       }
-    }, this.lockRefreshIntervalInMs, this.lockTimeoutInMs);
+    }, this.lockRefreshInterval.toMillis(), this.lockRefreshInterval.toMillis());
   }
 
   private void renameLockFile() {
-    String newLockFile = getNewLockFile();
+    LockFile newLockFile = getNewLockFile();
 
     try {
-      this.storage.commit(this.lockFile, newLockFile);
+      this.storage.commit(this.lockFile.filePath(), newLockFile.filePath());
       this.lockFile = newLockFile;
     } catch (Exception e) {
       log.error("Failed to rename the file", e);
     }
   }
 
-  private List<SimpleEntry<String, Matcher>> findLockFiles() {
-    List<FileStatus> walFiles = this.storage.list(this.lockDir);
-
-    return walFiles.stream()
-            .filter(fileStatus -> fileStatus.isFile())
-            .map((Function<FileStatus, Object>) fileStatus -> fileStatus.getPath()
-                    .getName())
-            .map(Object::toString)
-            .map(fileName -> new SimpleEntry<String, Matcher>(fileName,
-                                                              pattern.matcher(fileName)))
-            .filter(pair -> pair.getValue().matches())
-            .collect(Collectors.toList());
+  private List<LockFile> findLockFiles() {
+    return this.storage.list(this.lockDir)
+            .stream()
+            .filter(FileStatus::isFile)
+            .map(FileStatus::getPath)
+            .map(Path::getName)
+            .map(pattern::matcher)
+            .filter(Matcher::matches)
+            .map(m ->
+              new LockFile(
+                this.storage.url(),
+                this.logsDir,
+                this.topicPartition,
+                UUID.fromString(m.group("uuid")),
+                Instant.ofEpochSecond(Long.parseLong(m.group("epoch")))
+            )).collect(Collectors.toList());
   }
 
   @Override
   public void acquireLease() throws ConnectException {
-    List<SimpleEntry<String, Matcher>> lockFiles = this.findLockFiles();
-    if (lockFiles.size() == 0) {
+    List<LockFile> lockFiles = this.findLockFiles();
+
+    if (lockFiles.isEmpty()) {
       throw new ConnectException("The lock file is not present in the log dir");
     }
 
@@ -180,20 +206,19 @@ public class QFSWAL implements WAL {
       throw new ConnectException("More than one lock file reside in the log dir");
     }
 
-    String filename = lockFiles.get(0).getKey();
-    Matcher matcher = lockFiles.get(0).getValue();
+    LockFile lockFile = lockFiles.get(0);
 
-    if (!matcher.group(1).equals(this.uuid.toString())) {
+    if (!lockFile.uuid.equals(this.uuid)) {
       log.error(
-              "UUID of the lock file %s for %s-%s topic-partition does not match %s uuid",
-              filename,
+              "UUID of the lock file {} for {}-{} topic-partition does not match {} uuid",
+              lockFile.filePath(),
               this.topicPartition.topic(),
               this.topicPartition.partition(),
               this.uuid);
       throw new ConnectException("Lock uuid does not match");
     }
 
-    if (Long.parseLong(matcher.group(2)) < System.currentTimeMillis() - this.lockTimeoutInMs) {
+    if (lockFile.instant.isBefore(Instant.now().minus(this.lockTimeout))) {
       throw new ConnectException(
               "Lock file has not been renamed for more than the threshold");
     }
@@ -215,7 +240,7 @@ public class QFSWAL implements WAL {
   @Override
   public void close() throws ConnectException {
     this.timer.cancel();
-    this.storage.delete(this.lockFile);
+    this.storage.delete(this.lockFile.filePath());
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.connect.hdfs.wal;
 
 import io.confluent.connect.hdfs.FileUtils;
@@ -9,165 +24,206 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class QFSWAL implements WAL {
-    private static final String LOCK_FILE_EXTENSION = "lock-qfs";
-    private static final int DEFAULT_LOCK_REFRESH_INTERVAL_IN_MS = 10_000;
-    private static final int DEFAULT_LOCK_TIMEOUT_IN_MS = 60_000;
-    private final UUID uuid;
-    private final Timer timer;
-    private final HdfsStorage storage;
-    private final String logsDir;
-    private final TopicPartition topicPartition;
-    private final Pattern pattern;
-    private final String lockDir;
-    private String lockFile;
+  private static final String LOCK_FILE_EXTENSION = "lock-qfs";
+  private static final int DEFAULT_LOCK_REFRESH_INTERVAL_IN_MS = 10_000;
+  private static final int DEFAULT_LOCK_TIMEOUT_IN_MS = 60_000;
+  private final UUID uuid;
+  private final Timer timer;
+  private final HdfsStorage storage;
+  private final String logsDir;
+  private final TopicPartition topicPartition;
+  private final Pattern pattern;
+  private final String lockDir;
+  private String lockFile;
 
-    private final int lockRefreshIntervalInMs;
-    private final int lockTimeoutInMs;
-    private static final Logger log = LoggerFactory.getLogger(QFSWAL.class);
+  private final int lockRefreshIntervalInMs;
+  private final int lockTimeoutInMs;
+  private static final Logger log = LoggerFactory.getLogger(QFSWAL.class);
 
-    public QFSWAL(String logsDir, TopicPartition topicPartition, HdfsStorage storage) {
-        this(logsDir, topicPartition, storage, DEFAULT_LOCK_REFRESH_INTERVAL_IN_MS, DEFAULT_LOCK_TIMEOUT_IN_MS);
+  public QFSWAL(String logsDir, TopicPartition topicPartition, HdfsStorage storage) {
+    this(logsDir,
+         topicPartition,
+         storage,
+         DEFAULT_LOCK_REFRESH_INTERVAL_IN_MS,
+         DEFAULT_LOCK_TIMEOUT_IN_MS);
+  }
+
+  public QFSWAL(
+          String logsDir,
+          TopicPartition topicPartition,
+          HdfsStorage storage,
+          int lockRefreshIntervalInMs,
+          int lockTimeoutInMs
+  ) {
+    this.uuid = UUID.randomUUID();
+    this.pattern = Pattern.compile(String.format(
+            "([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-(\\d+)(\\.)%s",
+            LOCK_FILE_EXTENSION));
+    this.timer = new Timer("QFSWAL-Timer", true);
+    this.storage = storage;
+    this.logsDir = logsDir;
+    this.topicPartition = topicPartition;
+    this.lockDir = FileUtils.directoryName(storage.url(), logsDir, topicPartition);
+    this.lockFile = this.createOrRenameLockFile();
+    this.lockRefreshIntervalInMs = lockRefreshIntervalInMs;
+    this.lockTimeoutInMs = lockTimeoutInMs;
+    this.startRenamingTimer();
+  }
+
+  private String getNewLockFile() {
+    return FileUtils.fileName(storage.url(),
+                              this.logsDir,
+                              this.topicPartition,
+                              String.format("%s-%s.%s",
+                                            this.uuid,
+                                            System.currentTimeMillis(),
+                                            LOCK_FILE_EXTENSION));
+  }
+
+  private String createOrRenameLockFile() {
+    if (!this.storage.exists(this.lockDir)) {
+      this.storage.create(this.lockDir);
     }
 
-    public QFSWAL(String logsDir, TopicPartition topicPartition, HdfsStorage storage, int lockRefreshIntervalInMs, int lockTimeoutInMs) {
-        this.uuid = UUID.randomUUID();
-        this.pattern = Pattern.compile(String.format("([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-(\\d+)(\\.)%s", LOCK_FILE_EXTENSION));
-        this.timer = new Timer("QFSWAL-Timer", true);
-        this.storage = storage;
-        this.logsDir = logsDir;
-        this.topicPartition = topicPartition;
-        this.lockDir = FileUtils.directoryName(storage.url(), logsDir, topicPartition);
-        this.lockFile = this.createOrRenameLockFile();
-        this.lockRefreshIntervalInMs = lockRefreshIntervalInMs;
-        this.lockTimeoutInMs = lockTimeoutInMs;
-        this.startRenamingTimer();
+    List<SimpleEntry<String, Matcher>> lockFiles = this.findLockFiles();
+    String newLockFile = getNewLockFile();
+
+    long liveLocksCount = lockFiles.stream()
+            .filter(pair -> Long.parseLong(
+                    pair.getValue().group(2))
+                    > System.currentTimeMillis() - this.lockTimeoutInMs
+             ).count();
+
+    if (liveLocksCount != 0) {
+      throw new ConnectException("Lock has been acquired by another process");
     }
 
-    private String getNewLockFile() {
-        return FileUtils.fileName(storage.url(), this.logsDir, this.topicPartition, String.format("%s-%s.%s", this.uuid, System.currentTimeMillis(), LOCK_FILE_EXTENSION));
+    if (lockFiles.isEmpty()) {
+      this.storage.create(newLockFile, true);
+    } else {
+      String oldLockFile = FileUtils.fileName(storage.url(),
+                                              this.logsDir,
+                                              this.topicPartition,
+                                              lockFiles.get(0).getKey());
+      this.storage.commit(oldLockFile, newLockFile);
     }
 
-    private String createOrRenameLockFile() {
-        if (!this.storage.exists(this.lockDir)) {
-            this.storage.create(this.lockDir);
-        }
+    liveLocksCount = this.findLockFiles()
+            .stream()
+            .filter(pair -> Long.parseLong(
+                    pair.getValue().group(2))
+                    > System.currentTimeMillis() - this.lockTimeoutInMs
+            ).count();
 
-        List<SimpleEntry<String, Matcher>> lockFiles = this.findLockFiles();
-        String newLockFile = getNewLockFile();
-
-        long liveLocksCount = lockFiles.stream().filter(pair -> Long.parseLong(pair.getValue().group(2)) > System.currentTimeMillis() - this.lockTimeoutInMs).count();
-
-        if (liveLocksCount != 0) {
-            throw new ConnectException("Lock has been acquired by another process");
-        }
-
-        if (lockFiles.isEmpty()) {
-            this.storage.create(newLockFile, true);
-        } else {
-            String oldLockFile = FileUtils.fileName(storage.url(), this.logsDir, this.topicPartition, lockFiles.get(0).getKey());
-            this.storage.commit(oldLockFile, newLockFile);
-        }
-
-        liveLocksCount = this.findLockFiles().stream().filter(pair -> Long.parseLong(pair.getValue().group(2)) > System.currentTimeMillis() - this.lockTimeoutInMs).count();
-
-        if (liveLocksCount > 1) {
-            this.storage.delete(newLockFile);
-            throw new ConnectException("Lock has been acquired by another process");
-        }
-
-        return newLockFile;
+    if (liveLocksCount > 1) {
+      this.storage.delete(newLockFile);
+      throw new ConnectException("Lock has been acquired by another process");
     }
 
+    return newLockFile;
+  }
 
-    private void startRenamingTimer() {
-        this.timer.scheduleAtFixedRate(new TimerTask() {
-            @Override
-            public void run() {
-                renameLockFile();
-            }
-        }, this.lockRefreshIntervalInMs, this.lockTimeoutInMs);
+
+  private void startRenamingTimer() {
+    this.timer.scheduleAtFixedRate(new TimerTask() {
+      @Override
+      public void run() {
+        renameLockFile();
+      }
+    }, this.lockRefreshIntervalInMs, this.lockTimeoutInMs);
+  }
+
+  private void renameLockFile() {
+    String newLockFile = getNewLockFile();
+
+    try {
+      this.storage.commit(this.lockFile, newLockFile);
+      this.lockFile = newLockFile;
+    } catch (Exception e) {
+      log.error("Failed to rename the file", e);
+    }
+  }
+
+  private List<SimpleEntry<String, Matcher>> findLockFiles() {
+    List<FileStatus> walFiles = this.storage.list(this.lockDir);
+
+    return walFiles.stream()
+            .filter(fileStatus -> fileStatus.isFile())
+            .map((Function<FileStatus, Object>) fileStatus -> fileStatus.getPath()
+                    .getName())
+            .map(Object::toString)
+            .map(fileName -> new SimpleEntry<String, Matcher>(fileName,
+                                                              pattern.matcher(fileName)))
+            .filter(pair -> pair.getValue().matches())
+            .collect(Collectors.toList());
+  }
+
+  @Override
+  public void acquireLease() throws ConnectException {
+    List<SimpleEntry<String, Matcher>> lockFiles = this.findLockFiles();
+    if (lockFiles.size() == 0) {
+      throw new ConnectException("The lock file is not present in the log dir");
     }
 
-    private void renameLockFile() {
-        String newLockFile = getNewLockFile();
-
-        try {
-            this.storage.commit(this.lockFile, newLockFile);
-            this.lockFile = newLockFile;
-        } catch (Exception e) {
-            log.error("Failed to rename the file", e);
-        }
+    if (lockFiles.size() > 1) {
+      throw new ConnectException("More than one lock file reside in the log dir");
     }
 
-    private List<SimpleEntry<String, Matcher>> findLockFiles() {
-        List<FileStatus> walFiles = this.storage.list(this.lockDir);
+    String filename = lockFiles.get(0).getKey();
+    Matcher matcher = lockFiles.get(0).getValue();
 
-        return walFiles.stream()
-                .filter(fileStatus -> fileStatus.isFile())
-                .map((Function<FileStatus, Object>) fileStatus -> fileStatus.getPath().getName())
-                .map(Object::toString)
-                .map(fileName -> new SimpleEntry<String, Matcher>(fileName, pattern.matcher(fileName)))
-                .filter(pair -> pair.getValue().matches())
-                .collect(Collectors.toList());
+    if (!matcher.group(1).equals(this.uuid.toString())) {
+      log.error(
+              "UUID of the lock file %s for %s-%s topic-partition does not match %s uuid",
+              filename,
+              this.topicPartition.topic(),
+              this.topicPartition.partition(),
+              this.uuid);
+      throw new ConnectException("Lock uuid does not match");
     }
 
-    @Override
-    public void acquireLease() throws ConnectException {
-        List<SimpleEntry<String, Matcher>> lockFiles = this.findLockFiles();
-        if (lockFiles.size() == 0) {
-            throw new ConnectException("The lock file is not present in the log dir");
-        }
-
-        if (lockFiles.size() > 1) {
-            throw new ConnectException("More than one lock file reside in the log dir");
-        }
-
-        String filename = lockFiles.get(0).getKey();
-        Matcher matcher = lockFiles.get(0).getValue();
-
-        if (!matcher.group(1).equals(this.uuid.toString())) {
-            log.error("UUID of the lock file %s for %s-%s topic-partition does not match %s uuid", filename, this.topicPartition.topic(), this.topicPartition.partition(), this.uuid);
-            throw new ConnectException("Lock uuid does not match");
-        }
-
-        if (Long.parseLong(matcher.group(2)) < System.currentTimeMillis() - this.lockTimeoutInMs) {
-            throw new ConnectException("Lock file has not been renamed for more than the threshold");
-        }
+    if (Long.parseLong(matcher.group(2)) < System.currentTimeMillis() - this.lockTimeoutInMs) {
+      throw new ConnectException(
+              "Lock file has not been renamed for more than the threshold");
     }
+  }
 
-    @Override
-    public void append(String s, String s1) throws ConnectException {
-        this.acquireLease();
-    }
+  @Override
+  public void append(String s, String s1) throws ConnectException {
+    this.acquireLease();
+  }
 
-    @Override
-    public void apply() throws ConnectException {
-    }
+  @Override
+  public void apply() throws ConnectException {
+  }
 
-    @Override
-    public void truncate() throws ConnectException {
-    }
+  @Override
+  public void truncate() throws ConnectException {
+  }
 
-    @Override
-    public void close() throws ConnectException {
-        this.timer.cancel();
-    }
+  @Override
+  public void close() throws ConnectException {
+    this.timer.cancel();
+  }
 
-    @Override
-    public String getLogFile() {
-        return null;
-    }
+  @Override
+  public String getLogFile() {
+    return null;
+  }
 
-    @Override
-    public FilePathOffset extractLatestOffset() {
-        return null;
-    }
+  @Override
+  public FilePathOffset extractLatestOffset() {
+    return null;
+  }
 }

--- a/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
@@ -1,0 +1,174 @@
+package io.confluent.connect.hdfs.wal;
+
+import io.confluent.connect.hdfs.FileUtils;
+import io.confluent.connect.hdfs.storage.HdfsStorage;
+import io.confluent.connect.storage.wal.FilePathOffset;
+import io.confluent.connect.storage.wal.WAL;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class QFSWAL implements WAL {
+    private static final String LOCK_FILE_EXTENSION = "lock-qfs";
+    private static final int DEFAULT_LOCK_REFRESH_INTERVAL_IN_MS = 10_000;
+    private static final int DEFAULT_LOCK_TIMEOUT_IN_MS = 60_000;
+    private final UUID uuid;
+    private final Timer timer;
+    private final HdfsStorage storage;
+    private final String logsDir;
+    private final TopicPartition topicPartition;
+    private final Pattern pattern;
+    private final String lockDir;
+    private String lockFile;
+
+    private final int lockRefreshIntervalInMs;
+    private final int lockTimeoutInMs;
+    private static final Logger log = LoggerFactory.getLogger(QFSWAL.class);
+
+    public QFSWAL(String logsDir, TopicPartition topicPartition, HdfsStorage storage) {
+        this(logsDir, topicPartition, storage, DEFAULT_LOCK_REFRESH_INTERVAL_IN_MS, DEFAULT_LOCK_TIMEOUT_IN_MS);
+    }
+
+    public QFSWAL(String logsDir, TopicPartition topicPartition, HdfsStorage storage, int lockRefreshIntervalInMs, int lockTimeoutInMs) {
+        this.uuid = UUID.randomUUID();
+        this.pattern = Pattern.compile(String.format("([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-(\\d+)(\\.)%s", LOCK_FILE_EXTENSION));
+        this.timer = new Timer("QFSWAL-Timer", true);
+        this.storage = storage;
+        this.logsDir = logsDir;
+        this.topicPartition = topicPartition;
+        this.lockDir = FileUtils.directoryName(storage.url(), logsDir, topicPartition);
+        this.lockFile = this.createOrRenameLockFile();
+        this.lockRefreshIntervalInMs = lockRefreshIntervalInMs;
+        this.lockTimeoutInMs = lockTimeoutInMs;
+        this.startRenamingTimer();
+    }
+
+    private String getNewLockFile() {
+        return FileUtils.fileName(storage.url(), this.logsDir, this.topicPartition, String.format("%s-%s.%s", this.uuid, System.currentTimeMillis(), LOCK_FILE_EXTENSION));
+    }
+
+    private String createOrRenameLockFile() {
+        if (!this.storage.exists(this.lockDir)) {
+            this.storage.create(this.lockDir);
+        }
+
+        List<SimpleEntry<String, Matcher>> lockFiles = this.findLockFiles();
+        String newLockFile = getNewLockFile();
+
+        long liveLocksCount = lockFiles.stream().filter(pair -> Long.parseLong(pair.getValue().group(2)) > System.currentTimeMillis() - this.lockTimeoutInMs).count();
+
+        if (liveLocksCount != 0) {
+            throw new ConnectException("Lock has been acquired by another process");
+        }
+
+        if (lockFiles.isEmpty()) {
+            this.storage.create(newLockFile, true);
+        } else {
+            String oldLockFile = FileUtils.fileName(storage.url(), this.logsDir, this.topicPartition, lockFiles.get(0).getKey());
+            this.storage.commit(oldLockFile, newLockFile);
+        }
+
+        liveLocksCount = this.findLockFiles().stream().filter(pair -> Long.parseLong(pair.getValue().group(2)) > System.currentTimeMillis() - this.lockTimeoutInMs).count();
+
+        if (liveLocksCount > 1) {
+            this.storage.delete(newLockFile);
+            throw new ConnectException("Lock has been acquired by another process");
+        }
+
+        return newLockFile;
+    }
+
+
+    private void startRenamingTimer() {
+        this.timer.scheduleAtFixedRate(new TimerTask() {
+            @Override
+            public void run() {
+                renameLockFile();
+            }
+        }, this.lockRefreshIntervalInMs, this.lockTimeoutInMs);
+    }
+
+    private void renameLockFile() {
+        String newLockFile = getNewLockFile();
+
+        try {
+            this.storage.commit(this.lockFile, newLockFile);
+            this.lockFile = newLockFile;
+        } catch (Exception e) {
+            log.error("Failed to rename the file", e);
+        }
+    }
+
+    private List<SimpleEntry<String, Matcher>> findLockFiles() {
+        List<FileStatus> walFiles = this.storage.list(this.lockDir);
+
+        return walFiles.stream()
+                .filter(fileStatus -> fileStatus.isFile())
+                .map((Function<FileStatus, Object>) fileStatus -> fileStatus.getPath().getName())
+                .map(Object::toString)
+                .map(fileName -> new SimpleEntry<String, Matcher>(fileName, pattern.matcher(fileName)))
+                .filter(pair -> pair.getValue().matches())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void acquireLease() throws ConnectException {
+        List<SimpleEntry<String, Matcher>> lockFiles = this.findLockFiles();
+        if (lockFiles.size() == 0) {
+            throw new ConnectException("The lock file is not present in the log dir");
+        }
+
+        if (lockFiles.size() > 1) {
+            throw new ConnectException("More than one lock file reside in the log dir");
+        }
+
+        String filename = lockFiles.get(0).getKey();
+        Matcher matcher = lockFiles.get(0).getValue();
+
+        if (!matcher.group(1).equals(this.uuid.toString())) {
+            log.error("UUID of the lock file %s for %s-%s topic-partition does not match %s uuid", filename, this.topicPartition.topic(), this.topicPartition.partition(), this.uuid);
+            throw new ConnectException("Lock uuid does not match");
+        }
+
+        if (Long.parseLong(matcher.group(2)) < System.currentTimeMillis() - this.lockTimeoutInMs) {
+            throw new ConnectException("Lock file has not been renamed for more than the threshold");
+        }
+    }
+
+    @Override
+    public void append(String s, String s1) throws ConnectException {
+        this.acquireLease();
+    }
+
+    @Override
+    public void apply() throws ConnectException {
+    }
+
+    @Override
+    public void truncate() throws ConnectException {
+    }
+
+    @Override
+    public void close() throws ConnectException {
+        this.timer.cancel();
+    }
+
+    @Override
+    public String getLogFile() {
+        return null;
+    }
+
+    @Override
+    public FilePathOffset extractLatestOffset() {
+        return null;
+    }
+}

--- a/src/main/java/io/confluent/connect/hdfs/wal/WalType.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/WalType.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.hdfs.wal;
+
+
+import io.confluent.connect.hdfs.storage.HdfsStorage;
+import org.apache.kafka.common.TopicPartition;
+
+public enum WalType {
+  NOOP((storage, logsDir, tp) -> new NoopWAL()),
+
+  HDFS((logsDir, tp, storage) -> storage.hdfsWAL(logsDir, tp)),
+  QFS((logsDir, tp, storage) -> storage.qfsWAL(logsDir, tp));
+
+  interface BuilderFunction<A, B, C, D> {
+    D apply(A a, B b, C c);
+  }
+
+  private final BuilderFunction<String, TopicPartition, HdfsStorage, WAL> factoryMethod;
+
+  WalType(BuilderFunction<String, TopicPartition, HdfsStorage, WAL> factoryMethod) {
+    this.factoryMethod = factoryMethod;
+  }
+
+  public WAL create(String logsDir, TopicPartition tp, HdfsStorage storage) {
+    return factoryMethod.apply(logsDir, tp, storage);
+  }
+}

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
@@ -370,7 +370,7 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
     );
 
     for (TopicPartition tp: tempfiles.keySet()) {
-      WAL wal = storage.wal(logsDir, tp);
+      WAL wal = storage.hdfsWAL(logsDir, tp);
       List<String> tempList = tempfiles.get(tp);
       List<String> committedList = committedFiles.get(tp);
       wal.append(WAL.beginMarker, "");

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -94,7 +94,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     DataWriter hdfsWriter = new DataWriter(connectorConfig, context, avroData);
     partitioner = hdfsWriter.getPartitioner();
 
-    WAL wal = storage.wal(logsDir, TOPIC_PARTITION);
+    WAL wal = storage.hdfsWAL(logsDir, TOPIC_PARTITION);
 
     wal.append(WAL.beginMarker, "");
 

--- a/src/test/java/io/confluent/connect/hdfs/utils/MemoryStorage.java
+++ b/src/test/java/io/confluent/connect/hdfs/utils/MemoryStorage.java
@@ -148,7 +148,12 @@ public class MemoryStorage extends HdfsStorage {
   }
 
   @Override
-  public WAL wal(String topicsDir, TopicPartition topicPart) {
+  public WAL qfsWAL(String topicsDir, TopicPartition topicPart) {
+    return new MemoryWAL(topicsDir, topicPart, this);
+  }
+
+  @Override
+  public WAL hdfsWAL(String topicsDir, TopicPartition topicPart) {
     return new MemoryWAL(topicsDir, topicPart, this);
   }
 

--- a/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/FSWALTest.java
@@ -104,7 +104,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     setupWalTest();
     HdfsStorage storage = new HdfsStorage(connectorConfig, url);
 
-    FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
+    FSWAL wal = (FSWAL) storage.hdfsWAL(logsDir, TOPIC_PARTITION);
     //create a few empty blocks
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
@@ -128,7 +128,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     setupWalTest();
     HdfsStorage storage = new HdfsStorage(connectorConfig, url);
     // test missing end marker on middle block
-    FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
+    FSWAL wal = (FSWAL) storage.hdfsWAL(logsDir, TOPIC_PARTITION);
 
     wal.append(WAL.beginMarker, "");
     addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal, 5);
@@ -147,7 +147,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     setupWalTest();
     HdfsStorage storage = new HdfsStorage(connectorConfig, url);
     // test missing end marker on middle block
-    FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
+    FSWAL wal = (FSWAL) storage.hdfsWAL(logsDir, TOPIC_PARTITION);
     //create a few empty blocks
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
@@ -172,7 +172,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     setupWalTest();
     HdfsStorage storage = new HdfsStorage(connectorConfig, url);
     // test missing end marker on middle block
-    FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
+    FSWAL wal = (FSWAL) storage.hdfsWAL(logsDir, TOPIC_PARTITION);
     wal.append(WAL.beginMarker, "");
 
     String tempfile = FileUtils.tempFileName(url, topicsDir.get(TOPIC_PARTITION.topic()), getDirectory(), extension);
@@ -198,7 +198,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
     setupWalTest();
     HdfsStorage storage = new HdfsStorage(connectorConfig, url);
     // test missing end marker on middle block
-    FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
+    FSWAL wal = (FSWAL) storage.hdfsWAL(logsDir, TOPIC_PARTITION);
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
     wal.append(WAL.beginMarker, "");
@@ -211,7 +211,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
   public void testNoOffsetsFromWALWithMissingBeginMarkerFirstBlock() throws Exception {
     setupWalTest();
     HdfsStorage storage = new HdfsStorage(connectorConfig, url);
-    FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
+    FSWAL wal = (FSWAL) storage.hdfsWAL(logsDir, TOPIC_PARTITION);
 
     //test missing begin marker
     addSampleEntriesToWALNoMarkers(topicsDir.get(TOPIC_PARTITION.topic()), wal, 5);
@@ -224,7 +224,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
   public void testNoOffsetsFromWALWithMissingBeginMarkerMiddleBlock() throws Exception {
     setupWalTest();
     HdfsStorage storage = new HdfsStorage(connectorConfig, url);
-    FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
+    FSWAL wal = (FSWAL) storage.hdfsWAL(logsDir, TOPIC_PARTITION);
 
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
@@ -245,7 +245,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
   public void testNoOffsetsFromWALWithMissingBeginMarkerLastBlock() throws Exception {
     setupWalTest();
     HdfsStorage storage = new HdfsStorage(connectorConfig, url);
-    FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
+    FSWAL wal = (FSWAL) storage.hdfsWAL(logsDir, TOPIC_PARTITION);
 
     wal.append(WAL.beginMarker, "");
     wal.append(WAL.endMarker, "");
@@ -262,7 +262,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
   public void testOffsetsExtractedFromWAL() throws Exception {
     setupWalTest();
     HdfsStorage storage = new HdfsStorage(connectorConfig, url);
-    FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
+    FSWAL wal = (FSWAL) storage.hdfsWAL(logsDir, TOPIC_PARTITION);
     addSampleEntriesToWAL(topicsDir.get(TOPIC_PARTITION.topic()), wal, 5);
 
     long latestOffset = wal.extractLatestOffset().getOffset();
@@ -273,7 +273,7 @@ public class FSWALTest extends TestWithMiniDFSCluster {
   public void testOffsetsExtractedFromOldWAL() throws Exception {
     setupWalTest();
     HdfsStorage storage = new HdfsStorage(connectorConfig, url);
-    FSWAL wal = (FSWAL) storage.wal(logsDir, TOPIC_PARTITION);
+    FSWAL wal = (FSWAL) storage.hdfsWAL(logsDir, TOPIC_PARTITION);
     addSampleEntriesToWAL(topicsDir.get(TOPIC_PARTITION.topic()), wal, 5);
     //creates old WAL and empties new one
     wal.truncate();

--- a/src/test/java/io/confluent/connect/hdfs/wal/QFSWALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/QFSWALTest.java
@@ -7,6 +7,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -39,7 +40,7 @@ public class QFSWALTest extends TestWithMiniDFSCluster {
         setUp();
         HdfsStorage storage = new HdfsStorage(connectorConfig, url);
         TopicPartition tp = new TopicPartition("mytopic", 123);
-        QFSWAL wal = new QFSWAL("/logs", tp, storage, 500, 1000);
+        QFSWAL wal = new QFSWAL("/logs", tp, storage, Duration.ofMillis(500), Duration.ofMillis(1000));
         String fileName1 = storage.list("/logs/mytopic/123/").get(0).getPath().getName();
 
         Thread.sleep(1000);
@@ -57,7 +58,7 @@ public class QFSWALTest extends TestWithMiniDFSCluster {
         setUp();
         HdfsStorage storage = new HdfsStorage(connectorConfig, url);
         TopicPartition tp = new TopicPartition("mytopic", 123);
-        QFSWAL wal = new QFSWAL("/logs", tp, storage, 500, 1000);
+        QFSWAL wal = new QFSWAL("/logs", tp, storage, Duration.ofMillis(500), Duration.ofMillis(1000));
         wal.close();
 
         Thread.sleep(1500);
@@ -69,7 +70,7 @@ public class QFSWALTest extends TestWithMiniDFSCluster {
         setUp();
         HdfsStorage storage = new HdfsStorage(connectorConfig, url);
         TopicPartition tp = new TopicPartition("mytopic", 123);
-        QFSWAL wal = new QFSWAL("/logs", tp, storage, 1000, 2000);
+        QFSWAL wal = new QFSWAL("/logs", tp, storage, Duration.ofMillis(1000), Duration.ofMillis(2000));
 
         Thread.sleep(1500);
         wal.acquireLease();
@@ -80,10 +81,10 @@ public class QFSWALTest extends TestWithMiniDFSCluster {
         setUp();
         HdfsStorage storage = new HdfsStorage(connectorConfig, url);
         TopicPartition tp = new TopicPartition("mytopic", 123);
-        (new QFSWAL("/logs", tp, storage, 500, 1000)).close();
+        (new QFSWAL("/logs", tp, storage, Duration.ofMillis(500), Duration.ofMillis(1000))).close();
 
         Thread.sleep(1500);
-        QFSWAL wal = new QFSWAL("/logs", tp, storage, 500, 1000);
+        QFSWAL wal = new QFSWAL("/logs", tp, storage, Duration.ofMillis(500), Duration.ofMillis(1000));
         wal.acquireLease();
     }
 }

--- a/src/test/java/io/confluent/connect/hdfs/wal/QFSWALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/QFSWALTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import static org.junit.Assert.*;
 
 public class QFSWALTest extends TestWithMiniDFSCluster {
-
     @Test
     public void testLockCreating() throws Exception {
         setUp();
@@ -39,7 +38,7 @@ public class QFSWALTest extends TestWithMiniDFSCluster {
         setUp();
         HdfsStorage storage = new HdfsStorage(connectorConfig, url);
         TopicPartition tp = new TopicPartition("mytopic", 123);
-        QFSWAL wal = new QFSWAL("/logs", tp, storage, 1000, 2000);
+        QFSWAL wal = new QFSWAL("/logs", tp, storage, 500, 2000);
         String fileName1 = storage.list("/logs/mytopic/123/").get(0).getPath().getName();
 
         Thread.sleep(2000);

--- a/src/test/java/io/confluent/connect/hdfs/wal/QFSWALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/QFSWALTest.java
@@ -27,8 +27,9 @@ public class QFSWALTest extends TestWithMiniDFSCluster {
         setUp();
         HdfsStorage storage = new HdfsStorage(connectorConfig, url);
         TopicPartition tp = new TopicPartition("mytopic", 123);
-        new QFSWAL("/logs", tp, storage);
-        new QFSWAL("/logs", tp, storage);
+        new QFSWAL("logs", tp, storage);
+        new QFSWAL("logs", tp, storage);
+
         List<FileStatus> fs = storage.list("/logs/mytopic/123/");
         assertEquals(1, fs.size());
     }
@@ -38,13 +39,13 @@ public class QFSWALTest extends TestWithMiniDFSCluster {
         setUp();
         HdfsStorage storage = new HdfsStorage(connectorConfig, url);
         TopicPartition tp = new TopicPartition("mytopic", 123);
-        QFSWAL wal = new QFSWAL("/logs", tp, storage, 500, 2000);
+        QFSWAL wal = new QFSWAL("/logs", tp, storage, 500, 1000);
         String fileName1 = storage.list("/logs/mytopic/123/").get(0).getPath().getName();
 
-        Thread.sleep(2000);
+        Thread.sleep(1000);
         String fileName2 = storage.list("/logs/mytopic/123/").get(0).getPath().getName();
 
-        Thread.sleep(2000);
+        Thread.sleep(1000);
         String fileName3 = storage.list("/logs/mytopic/123/").get(0).getPath().getName();
 
         assertNotEquals(fileName1, fileName2);
@@ -56,10 +57,10 @@ public class QFSWALTest extends TestWithMiniDFSCluster {
         setUp();
         HdfsStorage storage = new HdfsStorage(connectorConfig, url);
         TopicPartition tp = new TopicPartition("mytopic", 123);
-        QFSWAL wal = new QFSWAL("/logs", tp, storage, 1000, 2000);
+        QFSWAL wal = new QFSWAL("/logs", tp, storage, 500, 1000);
         wal.close();
 
-        Thread.sleep(3000);
+        Thread.sleep(1500);
         wal.acquireLease();
     }
 
@@ -79,10 +80,10 @@ public class QFSWALTest extends TestWithMiniDFSCluster {
         setUp();
         HdfsStorage storage = new HdfsStorage(connectorConfig, url);
         TopicPartition tp = new TopicPartition("mytopic", 123);
-        (new QFSWAL("/logs", tp, storage, 1000, 2000)).close();
+        (new QFSWAL("/logs", tp, storage, 500, 1000)).close();
 
-        Thread.sleep(3000);
-        QFSWAL wal = new QFSWAL("/logs", tp, storage, 1000, 2000);
+        Thread.sleep(1500);
+        QFSWAL wal = new QFSWAL("/logs", tp, storage, 500, 1000);
         wal.acquireLease();
     }
 }

--- a/src/test/java/io/confluent/connect/hdfs/wal/QFSWALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/QFSWALTest.java
@@ -1,0 +1,89 @@
+package io.confluent.connect.hdfs.wal;
+
+import io.confluent.connect.hdfs.TestWithMiniDFSCluster;
+import io.confluent.connect.hdfs.storage.HdfsStorage;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class QFSWALTest extends TestWithMiniDFSCluster {
+
+    @Test
+    public void testLockCreating() throws Exception {
+        setUp();
+        HdfsStorage storage = new HdfsStorage(connectorConfig, url);
+        TopicPartition tp = new TopicPartition("mytopic", 123);
+        new QFSWAL("/logs", tp, storage);
+        List<FileStatus> fs = storage.list("/logs/mytopic/123/");
+        assertEquals(1, fs.size());
+    }
+
+    @Test(expected = ConnectException.class)
+    public void testSecondProcessCannotAcquireLock() throws Exception {
+        setUp();
+        HdfsStorage storage = new HdfsStorage(connectorConfig, url);
+        TopicPartition tp = new TopicPartition("mytopic", 123);
+        new QFSWAL("/logs", tp, storage);
+        new QFSWAL("/logs", tp, storage);
+        List<FileStatus> fs = storage.list("/logs/mytopic/123/");
+        assertEquals(1, fs.size());
+    }
+
+    @Test
+    public void testLockGetsRenamed() throws Exception {
+        setUp();
+        HdfsStorage storage = new HdfsStorage(connectorConfig, url);
+        TopicPartition tp = new TopicPartition("mytopic", 123);
+        QFSWAL wal = new QFSWAL("/logs", tp, storage, 1000, 2000);
+        String fileName1 = storage.list("/logs/mytopic/123/").get(0).getPath().getName();
+
+        Thread.sleep(2000);
+        String fileName2 = storage.list("/logs/mytopic/123/").get(0).getPath().getName();
+
+        Thread.sleep(2000);
+        String fileName3 = storage.list("/logs/mytopic/123/").get(0).getPath().getName();
+
+        assertNotEquals(fileName1, fileName2);
+        assertNotEquals(fileName2, fileName3);
+    }
+
+    @Test(expected = ConnectException.class)
+    public void testLockGetsTimedOut() throws Exception {
+        setUp();
+        HdfsStorage storage = new HdfsStorage(connectorConfig, url);
+        TopicPartition tp = new TopicPartition("mytopic", 123);
+        QFSWAL wal = new QFSWAL("/logs", tp, storage, 1000, 2000);
+        wal.close();
+
+        Thread.sleep(3000);
+        wal.acquireLease();
+    }
+
+    @Test
+    public void testAcquireLease() throws Exception {
+        setUp();
+        HdfsStorage storage = new HdfsStorage(connectorConfig, url);
+        TopicPartition tp = new TopicPartition("mytopic", 123);
+        QFSWAL wal = new QFSWAL("/logs", tp, storage, 1000, 2000);
+
+        Thread.sleep(1500);
+        wal.acquireLease();
+    }
+
+    @Test
+    public void testAnotherProcessCanGrabLockAfterTimeout() throws Exception {
+        setUp();
+        HdfsStorage storage = new HdfsStorage(connectorConfig, url);
+        TopicPartition tp = new TopicPartition("mytopic", 123);
+        (new QFSWAL("/logs", tp, storage, 1000, 2000)).close();
+
+        Thread.sleep(3000);
+        QFSWAL wal = new QFSWAL("/logs", tp, storage, 1000, 2000);
+        wal.acquireLease();
+    }
+}

--- a/src/test/java/io/confluent/connect/hdfs/wal/WALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/WALTest.java
@@ -51,8 +51,8 @@ public class WALTest extends TestWithMiniDFSCluster {
         connectorConfig,
         url
     );
-    final WAL wal1 = storage.wal(topicsDir, TOPIC_PARTITION);
-    final FSWAL wal2 = (FSWAL) storage.wal(topicsDir, TOPIC_PARTITION);
+    final WAL wal1 = storage.hdfsWAL(topicsDir, TOPIC_PARTITION);
+    final FSWAL wal2 = (FSWAL) storage.hdfsWAL(topicsDir, TOPIC_PARTITION);
 
     String directory = TOPIC + "/" + String.valueOf(PARTITION);
     final String tempfile = FileUtils.tempFileName(url, topicsDir, directory, extension);


### PR DESCRIPTION
## Problem
FSWal doesn't perform well on QFS due to caching and leasing in Chunkserver. This caused some issues with duplicate records which got resolved by using NoopWAL. However, NoopWAL didn't resolve for zombie writer as there's no locking mechanism and acquireLease doesn't perform.

## Solution
This PR introduces QFSWAL class which uses the atomic rename function to make sure the process still owns the lock by constantly renaming it. If the lock file has not been updated (renamed) for more than the threshold, then it throws ConnectException which is not caught in [deliverMessages](https://github.com/apache/kafka/blob/7872a1ff5b2e9a0fbbe3d71180a97e29f1549d4f/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java#L621-L625), therefore, the task gets killed. This should prevent zombie writer and prevent duplicate records due to that.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
