### PR TITLE
Fix: Use epoch-millis to find alive lives

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
@@ -70,7 +70,7 @@ public class QFSWAL implements WAL {
     this.uuid = UUID.randomUUID();
     this.pattern = Pattern.compile(String.format(
             "(?<uuid>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"
-                    + "-(?<epoch>\\d+)(\\.)%s",
+                    + "-(?<epoch_ms>\\d+)(\\.)%s",
             LOCK_FILE_EXTENSION));
     this.timer = new Timer("QFSWAL-Timer", true);
     this.storage = storage;
@@ -182,7 +182,7 @@ public class QFSWAL implements WAL {
                 this.logsDir,
                 this.topicPartition,
                 UUID.fromString(m.group("uuid")),
-                Instant.ofEpochSecond(Long.parseLong(m.group("epoch")))
+                Instant.ofEpochMilli(Long.parseLong(m.group("epoch_ms")))
             )).collect(Collectors.toList());
   }
 

--- a/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/QFSWAL.java
@@ -70,7 +70,7 @@ public class QFSWAL implements WAL {
     this.uuid = UUID.randomUUID();
     this.pattern = Pattern.compile(String.format(
             "(?<uuid>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"
-                    + "-(?<epoch_ms>\\d+)(\\.)%s",
+                    + "-(?<epochInMS>\\d+)(\\.)%s",
             LOCK_FILE_EXTENSION));
     this.timer = new Timer("QFSWAL-Timer", true);
     this.storage = storage;
@@ -182,7 +182,7 @@ public class QFSWAL implements WAL {
                 this.logsDir,
                 this.topicPartition,
                 UUID.fromString(m.group("uuid")),
-                Instant.ofEpochMilli(Long.parseLong(m.group("epoch_ms")))
+                Instant.ofEpochMilli(Long.parseLong(m.group("epochInMS")))
             )).collect(Collectors.toList());
   }
 


### PR DESCRIPTION
## Problem
It wrongly uses ofEpochSecond while reading the epoch-in-ms which causes locks be valid for much longer than intended. This PR fixes the issue by creating an Instant object using ofEpochMilli.
